### PR TITLE
Add mobile support

### DIFF
--- a/web/controls.js
+++ b/web/controls.js
@@ -1,0 +1,58 @@
+window.onload = () => {
+    'use strict';
+    // Define keys to insert
+    const keys = [
+        { name: 'up', key: 'arrowup', text: '🔼' },
+        { name: 'left', key: 'arrowleft', text: '◀️'},
+        { name: 'down', key: 'arrowdown', text: '🔽'},
+        { name: 'right', key: 'arrowright', text: '▶️'},
+        { name: 'restart', key: 'r', text: '↺'}
+    ];
+
+    const controlsElement = document.getElementById('controls');
+    const canvasElement = document.getElementById('game-canvas');
+    controlsElement.style.display = 'none';
+    
+    const appendButton = (element, key) => {
+        const button = document.createElement('button'); 
+        button.innerHTML = key.text;
+        button.className = 'control-button';
+        button.id = 'control-button-' + key.name;
+        button.addEventListener('mousedown', () => {
+            canvasElement.focus();
+            canvasElement.dispatchEvent(
+                new KeyboardEvent('keydown', { 
+                    'key': key.key
+                })
+            );
+        });
+        element.appendChild(button);
+    };
+
+    // Insert keys to document
+    keys.forEach(key => appendButton(controlsElement, key));
+
+    // Hide keys, if browser is (probably) not mobile
+    const isMobile = () => {
+        const ua = window.navigator.userAgent;
+        // if useragent string contains any of the strings below, browser is considered mobile
+        return ['Android', 'iPhone', 'iPad', 'iPod', 'IEMobile'].map(keyword => ua.includes(keyword)).includes(true);
+    };
+
+    const controlsToggleElement = document.getElementById('controls-toggle');
+
+    const toggleControls = () => {
+        if (controlsElement.style.display == 'none') {
+            controlsToggleElement.innerHTML = 'Hide mobile controls';
+            controlsElement.style.display = 'grid';
+        } else {
+            controlsToggleElement.innerHTML = 'Show mobile controls';
+            controlsElement.style.display = 'none';
+        }
+    };
+    if (isMobile()) {
+        toggleControls();
+    }
+    controlsToggleElement.addEventListener('click', toggleControls);
+    controlsToggleElement.style.display = 'block';
+};

--- a/web/game.js
+++ b/web/game.js
@@ -84,5 +84,15 @@ var drawscore = function(scores) {
         ctx.fillText(scores[i], blocksize*54, blocksize*4+20*i);
     }
 };
+
+const resizeCanvas = () => {
+    const displayWidth = Math.min(canvasWidth, document.documentElement.clientWidth * 0.95);
+    canvas.style.width =  displayWidth + "px";
+    canvas.style.height = displayWidth * (canvasHeight/canvasWidth) + 'px'
+};
+
+window.onresize = resizeCanvas;
+resizeCanvas();
+
 document.body.appendChild(canvas);
 canvas.focus();

--- a/web/index.html
+++ b/web/index.html
@@ -3,13 +3,17 @@
     <head>
         <meta charset='utf-8'>
         <meta name='description' content='Online multiplayer snake'>
+        <meta name='viewport' content='width=device-width, initial-scale=1'>
         <title>Snake</title>
         <link rel='stylesheet' href='style.css' type='text/css'>
+        <script src='controls.js'></script>
     </head>
     <body>
         <h1 id='main-heading'>onlinesnake.fun</h1>
         <script src='game.js'></script>
         <noscript>JavaScript has to be enabled to play this game.</noscript>
+        <a href="#" id="controls-toggle">Show mobile controls</a>
+        <div id="controls"></div>
         <footer>
             <a href='https://github.com/ilarikuoppala/onlinesnake'>GitHub</a>
         </footer>

--- a/web/style.css
+++ b/web/style.css
@@ -7,3 +7,48 @@
 #main-heading, footer {
     text-align: center;
 }
+
+.control-button {
+    width: 4rem;
+    height: 4rem;
+    text-align: center;
+}
+
+#controls {
+    display: none;
+    padding-top: 2rem;
+    grid-template-columns: repeat(3, 1fr);
+    width: 12rem;
+    margin: auto;
+}
+
+#controls-toggle {
+    display: none;
+    text-align: center;
+}
+
+#control-button-up {
+    grid-column: 2;
+    grid-row: 1;
+}
+
+#control-button-down {
+    grid-column: 2;
+    grid-row: 3;
+}
+
+#control-button-left {
+    grid-column: 1;
+    grid-row: 2;
+}
+
+#control-button-right {
+    grid-column: 3;
+    grid-row: 2;
+}
+
+#control-button-restart {
+    margin-top: 4rem;
+    grid-column: 2;
+    grid-row: 4;
+}


### PR DESCRIPTION
Fixes #6 
This PR adds simple buttons to control the game (4 directions and restart button) and limits the maximum width of the canvas while preserving aspect ratio. The controls should be visible automatically on mobile browsers, but can be shown and hidden on all devices (supporting javascript).
![onelinesnake_mobile](https://user-images.githubusercontent.com/35733458/94936231-a7396100-04d6-11eb-911a-12fb16fcd0ad.jpg)

